### PR TITLE
Typo in pre-commit example from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ repos:
     rev: 0.1.0
     hooks:
       - id: cercis
-        args: [--function-definition-extra-indent=False, --ling-length=79]
+        args: [--function-definition-extra-indent=False, --line-length=79]
   - repo: https://github.com/jsh9/cercis
     rev: 0.1.0
     hooks:


### PR DESCRIPTION
Hopefully self-explanatory

_\*Sending signal to you that this should get the magical label to silence the CHANGELOG entry check.\*_